### PR TITLE
feat: sentence linter using associated types

### DIFF
--- a/harper-core/src/linting/a_part.rs
+++ b/harper-core/src/linting/a_part.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::FixedPhrase;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -26,6 +27,8 @@ impl Default for APart {
 }
 
 impl ExprLinter for APart {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/addicting.rs
+++ b/harper-core/src/linting/addicting.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{All, AnchorEnd, Expr, FirstMatchOf, LongestMatchOf, ReflexivePronoun, SequenceExpr},
@@ -34,6 +35,8 @@ impl Default for Addicting {
 }
 
 impl ExprLinter for Addicting {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/adjective_double_degree.rs
+++ b/harper-core/src/linting/adjective_double_degree.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -21,6 +22,8 @@ impl Default for AdjectiveDoubleDegree {
 }
 
 impl ExprLinter for AdjectiveDoubleDegree {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/after_later.rs
+++ b/harper-core/src/linting/after_later.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::{DurationExpr, Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::token_string_ext::TokenStringExt;
 
@@ -41,6 +42,8 @@ impl Default for AfterLater {
 }
 
 impl ExprLinter for AfterLater {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/all_intents_and_purposes.rs
+++ b/harper-core/src/linting/all_intents_and_purposes.rs
@@ -1,6 +1,7 @@
 use crate::Token;
 use crate::char_string::CharStringExt;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::token_string_ext::TokenStringExt;
 
@@ -41,6 +42,8 @@ impl Default for AllIntentsAndPurposes {
 }
 
 impl ExprLinter for AllIntentsAndPurposes {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/allow_to.rs
+++ b/harper-core/src/linting/allow_to.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind};
 use crate::token::Token;
 use crate::token_string_ext::TokenStringExt;
@@ -24,6 +25,8 @@ impl Default for AllowTo {
 }
 
 impl ExprLinter for AllowTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.exp.as_ref()
     }

--- a/harper-core/src/linting/am_in_the_morning.rs
+++ b/harper-core/src/linting/am_in_the_morning.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Span, Token, TokenStringExt,
     expr::{Expr, FixedPhrase, LongestMatchOf, SequenceExpr},
@@ -40,6 +41,8 @@ impl Default for AmInTheMorning {
 }
 
 impl ExprLinter for AmInTheMorning {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/amounts_for.rs
+++ b/harper-core/src/linting/amounts_for.rs
@@ -5,6 +5,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct AmountsFor {
     expr: Box<dyn Expr>,
@@ -38,6 +39,8 @@ impl Default for AmountsFor {
 }
 
 impl ExprLinter for AmountsFor {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/and_in.rs
+++ b/harper-core/src/linting/and_in.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 
 pub struct AndIn {
@@ -15,6 +16,8 @@ impl Default for AndIn {
 }
 
 impl ExprLinter for AndIn {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         &*self.expr
     }

--- a/harper-core/src/linting/another_thing_coming.rs
+++ b/harper-core/src/linting/another_thing_coming.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, FixedPhrase, SequenceExpr},
@@ -23,6 +24,8 @@ impl Default for AnotherThingComing {
 }
 
 impl ExprLinter for AnotherThingComing {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/another_think_coming.rs
+++ b/harper-core/src/linting/another_think_coming.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, FixedPhrase, SequenceExpr},
@@ -23,6 +24,8 @@ impl Default for AnotherThinkComing {
 }
 
 impl ExprLinter for AnotherThinkComing {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/ask_no_preposition.rs
+++ b/harper-core/src/linting/ask_no_preposition.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Span, Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -32,6 +33,8 @@ impl Default for AskNoPreposition {
 }
 
 impl ExprLinter for AskNoPreposition {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/avoid_curses.rs
+++ b/harper-core/src/linting/avoid_curses.rs
@@ -3,6 +3,7 @@ use crate::expr::{Expr, SequenceExpr};
 use crate::linting::{LintKind, Suggestion};
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
 
 pub struct AvoidCurses {
     expr: Box<dyn Expr>,
@@ -17,6 +18,8 @@ impl Default for AvoidCurses {
 }
 
 impl ExprLinter for AvoidCurses {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/back_in_the_day.rs
+++ b/harper-core/src/linting/back_in_the_day.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct BackInTheDay {
     expr: Box<dyn Expr>,
@@ -34,6 +35,8 @@ impl Default for BackInTheDay {
 }
 
 impl ExprLinter for BackInTheDay {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/be_allowed.rs
+++ b/harper-core/src/linting/be_allowed.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -51,6 +52,8 @@ impl Default for BeAllowed {
 }
 
 impl ExprLinter for BeAllowed {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/best_of_all_time.rs
+++ b/harper-core/src/linting/best_of_all_time.rs
@@ -3,6 +3,7 @@ use crate::expr::{Expr, SequenceExpr};
 use crate::patterns::WhitespacePattern;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct BestOfAllTime {
     expr: Box<dyn Expr>,
@@ -37,6 +38,8 @@ impl Default for BestOfAllTime {
 }
 
 impl ExprLinter for BestOfAllTime {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/boring_words.rs
+++ b/harper-core/src/linting/boring_words.rs
@@ -2,6 +2,7 @@ use crate::expr::{Expr, WordExprGroup};
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct BoringWords {
     expr: Box<dyn Expr>,
@@ -24,6 +25,8 @@ impl Default for BoringWords {
 }
 
 impl ExprLinter for BoringWords {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/bought.rs
+++ b/harper-core/src/linting/bought.rs
@@ -2,6 +2,7 @@ use super::{ExprLinter, Lint, LintKind};
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 
 pub struct Bought {
     expr: Box<dyn Expr>,
@@ -24,6 +25,8 @@ impl Default for Bought {
 }
 
 impl ExprLinter for Bought {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/call_them.rs
+++ b/harper-core/src/linting/call_them.rs
@@ -5,6 +5,7 @@ use crate::patterns::{DerivedFrom, WordSet};
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct CallThem {
     expr: Box<dyn Expr>,
@@ -53,6 +54,8 @@ impl Default for CallThem {
 }
 
 impl ExprLinter for CallThem {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/cant.rs
+++ b/harper-core/src/linting/cant.rs
@@ -2,6 +2,7 @@ use super::{ExprLinter, Suggestion};
 use crate::Lint;
 use crate::expr::{Expr, LongestMatchOf, SequenceExpr};
 use crate::linting::LintKind;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::expr_linter::find_the_only_token_matching;
 use crate::{CharStringExt, Token};
 
@@ -31,6 +32,8 @@ impl Default for Cant {
 }
 
 impl ExprLinter for Cant {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/cautionary_tale.rs
+++ b/harper-core/src/linting/cautionary_tale.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, SequenceExpr},
@@ -27,6 +28,8 @@ impl Default for CautionaryTale {
 }
 
 impl ExprLinter for CautionaryTale {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/change_tack.rs
+++ b/harper-core/src/linting/change_tack.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::patterns::Word;
 
@@ -33,6 +34,8 @@ impl Default for ChangeTack {
 }
 
 impl ExprLinter for ChangeTack {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/chock_full.rs
+++ b/harper-core/src/linting/chock_full.rs
@@ -4,6 +4,7 @@ use crate::expr::SpaceOrHyphen;
 use crate::{Token, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ChockFull {
     expr: Box<dyn Expr>,
@@ -23,6 +24,8 @@ impl Default for ChockFull {
 }
 
 impl ExprLinter for ChockFull {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_det_adj.rs
@@ -5,6 +5,7 @@ use crate::expr::SequenceExpr;
 use crate::{CharStringExt, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
+use crate::linting::expr_linter::Chunk;
 
 use crate::{Lrc, Token};
 
@@ -53,6 +54,8 @@ impl Default for CompoundNounAfterDetAdj {
 }
 
 impl ExprLinter for CompoundNounAfterDetAdj {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_after_possessive.rs
@@ -6,6 +6,7 @@ use crate::patterns::AnyPattern;
 use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
+use crate::linting::expr_linter::Chunk;
 
 use crate::Token;
 
@@ -52,6 +53,8 @@ impl Default for CompoundNounAfterPossessive {
 }
 
 impl ExprLinter for CompoundNounAfterPossessive {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
+++ b/harper-core/src/linting/compound_nouns/compound_noun_before_aux_verb.rs
@@ -8,6 +8,7 @@ use crate::{CharStringExt, Lrc, TokenStringExt, linting::ExprLinter};
 use super::{Lint, LintKind, Suggestion, is_content_word, predicate};
 
 use crate::Token;
+use crate::linting::expr_linter::Chunk;
 
 /// Two adjacent words separated by whitespace that if joined would be a valid noun.
 pub struct CompoundNounBeforeAuxVerb {
@@ -44,6 +45,8 @@ impl Default for CompoundNounBeforeAuxVerb {
 }
 
 impl ExprLinter for CompoundNounBeforeAuxVerb {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/compound_subject_i.rs
+++ b/harper-core/src/linting/compound_subject_i.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind,
     expr::{AnchorStart, Expr, SequenceExpr},
@@ -41,6 +42,8 @@ impl Default for CompoundSubjectI {
 }
 
 impl ExprLinter for CompoundSubjectI {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/confident.rs
+++ b/harper-core/src/linting/confident.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{Token, patterns::Word};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
@@ -28,6 +29,8 @@ impl Default for Confident {
 }
 
 impl ExprLinter for Confident {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/criteria_phenomena.rs
+++ b/harper-core/src/linting/criteria_phenomena.rs
@@ -3,6 +3,7 @@ use super::expr_linter::ExprLinter;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::LintKind;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 use crate::{Lint, Lrc, Token, TokenStringExt};
 
@@ -33,6 +34,8 @@ impl CriteriaPhenomena {
 }
 
 impl ExprLinter for CriteriaPhenomena {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/dashes.rs
+++ b/harper-core/src/linting/dashes.rs
@@ -4,6 +4,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 const EN_DASH: char = '–';
 const EM_DASH: char = '—';
@@ -29,6 +30,8 @@ impl Default for Dashes {
 }
 
 impl ExprLinter for Dashes {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/despite_of.rs
+++ b/harper-core/src/linting/despite_of.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct DespiteOf {
     expr: Box<dyn Expr>,
@@ -21,6 +22,8 @@ impl Default for DespiteOf {
 }
 
 impl ExprLinter for DespiteOf {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/determiner_without_noun.rs
+++ b/harper-core/src/linting/determiner_without_noun.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct DeterminerWithoutNoun {
     expr: Box<dyn Expr>,
@@ -22,6 +23,8 @@ impl Default for DeterminerWithoutNoun {
 }
 
 impl ExprLinter for DeterminerWithoutNoun {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/didnt.rs
+++ b/harper-core/src/linting/didnt.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 
 pub struct Didnt {
@@ -20,6 +21,8 @@ impl Default for Didnt {
 }
 
 impl ExprLinter for Didnt {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/dot_initialisms.rs
+++ b/harper-core/src/linting/dot_initialisms.rs
@@ -4,6 +4,7 @@ use crate::expr::WordExprGroup;
 use hashbrown::HashMap;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 use crate::{Token, TokenStringExt};
 
 pub struct DotInitialisms {
@@ -35,6 +36,8 @@ impl Default for DotInitialisms {
 }
 
 impl ExprLinter for DotInitialisms {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/double_click.rs
+++ b/harper-core/src/linting/double_click.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind, TokenStringExt,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -57,6 +58,8 @@ impl Default for DoubleClick {
 }
 
 impl ExprLinter for DoubleClick {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/double_modal.rs
+++ b/harper-core/src/linting/double_modal.rs
@@ -5,6 +5,7 @@ use crate::{Token, TokenStringExt};
 
 use super::Suggestion;
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct DoubleModal {
     expr: Box<dyn Expr>,
@@ -24,6 +25,8 @@ impl Default for DoubleModal {
 }
 
 impl ExprLinter for DoubleModal {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/else_possessive.rs
+++ b/harper-core/src/linting/else_possessive.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -36,6 +37,8 @@ impl Default for ElsePossessive {
 }
 
 impl ExprLinter for ElsePossessive {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/everyday.rs
+++ b/harper-core/src/linting/everyday.rs
@@ -3,6 +3,7 @@ use crate::expr::All;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{Lrc, Punctuation, Token, TokenKind, TokenStringExt, patterns::Word};
 
 pub struct Everyday {
@@ -147,6 +148,8 @@ impl Default for Everyday {
 }
 
 impl ExprLinter for Everyday {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/expand_memory_shorthands.rs
+++ b/harper-core/src/linting/expand_memory_shorthands.rs
@@ -4,6 +4,7 @@ use super::{ExprLinter, Lint, LintKind};
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::{ImpliesQuantity, WordSet};
 
 pub struct ExpandMemoryShorthands {
@@ -74,6 +75,8 @@ impl Default for ExpandMemoryShorthands {
 }
 
 impl ExprLinter for ExpandMemoryShorthands {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/expand_time_shorthands.rs
+++ b/harper-core/src/linting/expand_time_shorthands.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use super::{ExprLinter, Lint, LintKind};
 use crate::Token;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::{ImpliesQuantity, WordSet};
 
 pub struct ExpandTimeShorthands {
@@ -57,6 +58,8 @@ impl Default for ExpandTimeShorthands {
 }
 
 impl ExprLinter for ExpandTimeShorthands {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/far_be_it.rs
+++ b/harper-core/src/linting/far_be_it.rs
@@ -1,5 +1,6 @@
 use crate::char_string::CharStringExt;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::token::Token;
 
@@ -25,6 +26,8 @@ impl Default for FarBeIt {
 }
 
 impl ExprLinter for FarBeIt {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/feel_fell.rs
+++ b/harper-core/src/linting/feel_fell.rs
@@ -1,6 +1,7 @@
 use crate::Token;
 use crate::char_string::CharStringExt;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::expr_linter::find_the_only_token_matching;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 
@@ -42,6 +43,8 @@ impl Default for FeelFell {
 }
 
 impl ExprLinter for FeelFell {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/few_units_of_time_ago.rs
+++ b/harper-core/src/linting/few_units_of_time_ago.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::expr::TimeUnitExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token,
     linting::{ExprLinter, Lint, Suggestion},
@@ -33,6 +34,8 @@ impl Default for FewUnitsOfTimeAgo {
 }
 
 impl ExprLinter for FewUnitsOfTimeAgo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/filler_words.rs
+++ b/harper-core/src/linting/filler_words.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -30,6 +31,8 @@ impl Default for FillerWords {
 }
 
 impl ExprLinter for FillerWords {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/first_aid_kit.rs
+++ b/harper-core/src/linting/first_aid_kit.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -24,6 +25,8 @@ impl Default for FirstAidKit {
 }
 
 impl ExprLinter for FirstAidKit {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/for_noun.rs
+++ b/harper-core/src/linting/for_noun.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ForNoun {
     expr: Box<dyn Expr>,
@@ -25,6 +26,8 @@ impl Default for ForNoun {
 }
 
 impl ExprLinter for ForNoun {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/free_predicate.rs
+++ b/harper-core/src/linting/free_predicate.rs
@@ -7,6 +7,7 @@ use crate::expr::{Expr, ExprMap, SequenceExpr};
 use crate::patterns::WhitespacePattern;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct FreePredicate {
     expr: Box<dyn Expr>,
@@ -47,6 +48,8 @@ impl Default for FreePredicate {
 }
 
 impl ExprLinter for FreePredicate {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/friend_of_me.rs
+++ b/harper-core/src/linting/friend_of_me.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, SequenceExpr},
@@ -23,6 +24,8 @@ impl Default for FriendOfMe {
 }
 
 impl ExprLinter for FriendOfMe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/go_so_far_as_to.rs
+++ b/harper-core/src/linting/go_so_far_as_to.rs
@@ -2,6 +2,7 @@ use crate::Token;
 use crate::TokenStringExt;
 use crate::expr::{Expr, SequenceExpr};
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind};
 
 pub struct GoSoFarAsTo {
@@ -22,6 +23,8 @@ impl Default for GoSoFarAsTo {
 }
 
 impl ExprLinter for GoSoFarAsTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.exp.as_ref()
     }

--- a/harper-core/src/linting/have_pronoun.rs
+++ b/harper-core/src/linting/have_pronoun.rs
@@ -2,6 +2,7 @@ use crate::expr::{AnchorStart, Expr, SequenceExpr};
 use crate::{Token, TokenKind};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct HavePronoun {
     expr: Box<dyn Expr>,
@@ -25,6 +26,8 @@ impl Default for HavePronoun {
 }
 
 impl ExprLinter for HavePronoun {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/have_take_a_look.rs
+++ b/harper-core/src/linting/have_take_a_look.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Dialect, Token,
     expr::{Expr, FixedPhrase, SequenceExpr},
@@ -31,6 +32,8 @@ impl HaveTakeALook {
 }
 
 impl ExprLinter for HaveTakeALook {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hedging.rs
+++ b/harper-core/src/linting/hedging.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::FixedPhrase;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind};
 use crate::{Token, TokenStringExt};
 
@@ -24,6 +25,8 @@ impl Default for Hedging {
 }
 
 impl ExprLinter for Hedging {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hello_greeting.rs
+++ b/harper-core/src/linting/hello_greeting.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{AnchorStart, Expr, SequenceExpr},
@@ -27,6 +28,8 @@ impl Default for HelloGreeting {
 }
 
 impl ExprLinter for HelloGreeting {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hereby.rs
+++ b/harper-core/src/linting/hereby.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct Hereby {
     expr: Box<dyn Expr>,
@@ -23,6 +24,8 @@ impl Default for Hereby {
 }
 
 impl ExprLinter for Hereby {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hop_hope/to_hop.rs
+++ b/harper-core/src/linting/hop_hope/to_hop.rs
@@ -2,6 +2,7 @@ use super::super::{ExprLinter, Lint, LintKind};
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 use crate::{CharString, CharStringExt};
 use crate::{Token, char_string::char_string};
@@ -39,6 +40,8 @@ impl ToHop {
 }
 
 impl ExprLinter for ToHop {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hop_hope/to_hope.rs
+++ b/harper-core/src/linting/hop_hope/to_hope.rs
@@ -2,6 +2,7 @@ use super::super::{ExprLinter, Lint, LintKind};
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 use crate::{Token, char_string::char_string};
 
@@ -25,6 +26,8 @@ impl Default for ToHope {
 }
 
 impl ExprLinter for ToHope {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hope_youre.rs
+++ b/harper-core/src/linting/hope_youre.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::SequenceExpr,
@@ -31,6 +32,8 @@ impl Default for HopeYoure {
 }
 
 impl ExprLinter for HopeYoure {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn crate::expr::Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/how_to.rs
+++ b/harper-core/src/linting/how_to.rs
@@ -1,5 +1,6 @@
 use harper_brill::UPOS;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind, TokenStringExt,
     expr::{All, Expr, OwnedExprExt, SequenceExpr},
@@ -49,6 +50,8 @@ impl Default for HowTo {
 }
 
 impl ExprLinter for HowTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/hyphenate_number_day.rs
+++ b/harper-core/src/linting/hyphenate_number_day.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, patterns::NominalPhrase};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct HyphenateNumberDay {
     expr: Box<dyn Expr>,
@@ -36,6 +37,8 @@ impl Default for HyphenateNumberDay {
 }
 
 impl ExprLinter for HyphenateNumberDay {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/i_am_agreement.rs
+++ b/harper-core/src/linting/i_am_agreement.rs
@@ -1,8 +1,10 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token, TokenStringExt,
     expr::{AnchorStart, Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
     linting::{ExprLinter, Lint, LintKind, Suggestion},
 };
+
 pub struct IAmAgreement {
     expr: Box<dyn Expr>,
 }
@@ -34,6 +36,8 @@ impl Default for IAmAgreement {
 }
 
 impl ExprLinter for IAmAgreement {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/if_wouldve.rs
+++ b/harper-core/src/linting/if_wouldve.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::patterns::{NominalPhrase, WordSet};
 use crate::token_string_ext::TokenStringExt;
@@ -33,6 +34,8 @@ impl Default for IfWouldve {
 }
 
 impl ExprLinter for IfWouldve {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/in_on_the_cards.rs
+++ b/harper-core/src/linting/in_on_the_cards.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
 
 pub struct InOnTheCards {
     expr: Box<dyn Expr>,
@@ -41,6 +42,8 @@ impl InOnTheCards {
 }
 
 impl ExprLinter for InOnTheCards {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/initialism_linter.rs
+++ b/harper-core/src/linting/initialism_linter.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 use crate::{Token, patterns::Word};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 /// A struct that can be composed to expand initialisms, respecting the capitalization of each
 /// item.
@@ -29,6 +30,8 @@ impl InitialismLinter {
 }
 
 impl ExprLinter for InitialismLinter {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/interested_in.rs
+++ b/harper-core/src/linting/interested_in.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenKind,
     expr::{Expr, SequenceExpr},
@@ -25,6 +26,8 @@ impl Default for InterestedIn {
 }
 
 impl ExprLinter for InterestedIn {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/it_is.rs
+++ b/harper-core/src/linting/it_is.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -51,6 +52,8 @@ impl Default for ItIs {
 }
 
 impl ExprLinter for ItIs {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/it_looks_like_that.rs
+++ b/harper-core/src/linting/it_looks_like_that.rs
@@ -1,5 +1,6 @@
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::token_string_ext::TokenStringExt;
 
@@ -43,6 +44,8 @@ impl Default for ItLooksLikeThat {
 }
 
 impl ExprLinter for ItLooksLikeThat {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/it_would_be.rs
+++ b/harper-core/src/linting/it_would_be.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -64,6 +65,8 @@ impl Default for ItWouldBe {
 }
 
 impl ExprLinter for ItWouldBe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/its_possessive.rs
+++ b/harper-core/src/linting/its_possessive.rs
@@ -12,6 +12,7 @@ use crate::patterns::UPOSSet;
 use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ItsPossessive {
     expr: Box<dyn Expr>,
@@ -73,6 +74,8 @@ impl Default for ItsPossessive {
 }
 
 impl ExprLinter for ItsPossessive {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/left_right_hand.rs
+++ b/harper-core/src/linting/left_right_hand.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct LeftRightHand {
     expr: Box<dyn Expr>,
@@ -24,6 +25,8 @@ impl Default for LeftRightHand {
 }
 
 impl ExprLinter for LeftRightHand {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/less_worse.rs
+++ b/harper-core/src/linting/less_worse.rs
@@ -3,6 +3,7 @@ use crate::patterns::WordSet;
 use crate::{CharStringExt, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct LessWorse {
     expr: Box<dyn Expr>,
@@ -22,6 +23,8 @@ impl Default for LessWorse {
 }
 
 impl ExprLinter for LessWorse {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/let_to_do.rs
+++ b/harper-core/src/linting/let_to_do.rs
@@ -4,6 +4,7 @@ use crate::linting::{LintKind, Suggestion};
 use crate::token_string_ext::TokenStringExt;
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
 
 pub struct LetToDo {
     expr: Box<dyn Expr>,
@@ -47,6 +48,8 @@ impl Default for LetToDo {
 }
 
 impl ExprLinter for LetToDo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
+++ b/harper-core/src/linting/lets_confusion/let_us_redundancy.rs
@@ -2,6 +2,7 @@ use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 
 /// See also:
@@ -24,6 +25,8 @@ impl Default for LetUsRedundancy {
 }
 
 impl ExprLinter for LetUsRedundancy {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
+++ b/harper-core/src/linting/lets_confusion/no_contraction_with_verb.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 use crate::linting::ExprLinter;
+use crate::linting::expr_linter::Chunk;
 
 /// See also:
 /// harper-core/src/linting/compound_nouns/implied_ownership_compound_nouns.rs
@@ -57,6 +58,8 @@ impl Default for NoContractionWithVerb {
 }
 
 impl ExprLinter for NoContractionWithVerb {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/likewise.rs
+++ b/harper-core/src/linting/likewise.rs
@@ -4,6 +4,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct Likewise {
     expr: Box<dyn Expr>,
@@ -30,6 +31,8 @@ impl Default for Likewise {
     }
 }
 impl ExprLinter for Likewise {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/lint_group.rs
+++ b/harper-core/src/linting/lint_group.rs
@@ -179,6 +179,7 @@ use super::would_never_have::WouldNeverHave;
 use super::{CurrencyPlacement, HtmlDescriptionLinter, Linter, NoOxfordComma, OxfordComma};
 use super::{ExprLinter, Lint};
 use crate::linting::dashes::Dashes;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::open_compounds::OpenCompounds;
 use crate::linting::{
     MassPlurals, NounVerbConfusion, closed_compounds, initialisms, phrase_corrections,
@@ -300,7 +301,7 @@ pub struct LintGroup {
     /// We use a binary map here so the ordering is stable.
     linters: BTreeMap<String, Box<dyn Linter>>,
     /// We use a binary map here so the ordering is stable.
-    expr_linters: BTreeMap<String, Box<dyn ExprLinter>>,
+    expr_linters: BTreeMap<String, Box<dyn ExprLinter<Unit = Chunk>>>,
     /// Since [`ExprLinter`]s operate on a chunk-basis, we can store a
     /// mapping of `Chunk -> Lint` and only re-run the expr linters
     /// when a chunk changes.
@@ -347,13 +348,16 @@ impl LintGroup {
     pub fn add_expr_linter(
         &mut self,
         name: impl AsRef<str>,
-        linter: impl ExprLinter + 'static,
+        // linter: impl ExprLinter + 'static,
+        linter: impl ExprLinter<Unit = Chunk> + 'static,
     ) -> bool {
         if self.contains_key(&name) {
             false
         } else {
             self.expr_linters
-                .insert(name.as_ref().to_string(), Box::new(linter));
+                // .insert(name.as_ref().to_string(), Box::new(linter));
+                // .insert(name.as_ref().to_string(), Box::new(linter) as Box<dyn ExprLinter<ExLiType = ExLiSt>>);
+                .insert(name.as_ref().to_string(), Box::new(linter) as _);
             true
         }
     }

--- a/harper-core/src/linting/looking_forward_to.rs
+++ b/harper-core/src/linting/looking_forward_to.rs
@@ -1,5 +1,6 @@
 use hashbrown::HashSet;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, FixedPhrase, SequenceExpr},
@@ -27,6 +28,8 @@ impl Default for LookingForwardTo {
 }
 
 impl ExprLinter for LookingForwardTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/map_phrase_linter.rs
+++ b/harper-core/src/linting/map_phrase_linter.rs
@@ -4,6 +4,7 @@ use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
 use crate::expr::SimilarToPhrase;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::{Token, TokenStringExt};
 
 pub struct MapPhraseLinter {
@@ -105,6 +106,8 @@ impl MapPhraseLinter {
 }
 
 impl ExprLinter for MapPhraseLinter {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/map_phrase_set_linter.rs
+++ b/harper-core/src/linting/map_phrase_set_linter.rs
@@ -4,6 +4,7 @@ use crate::expr::Expr;
 use crate::expr::FixedPhrase;
 use crate::expr::LongestMatchOf;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::{Token, TokenStringExt};
 
 pub struct MapPhraseSetLinter<'a> {
@@ -68,6 +69,8 @@ impl<'a> MapPhraseSetLinter<'a> {
 }
 
 impl<'a> ExprLinter for MapPhraseSetLinter<'a> {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/mass_plurals.rs
+++ b/harper-core/src/linting/mass_plurals.rs
@@ -1,5 +1,6 @@
 use hashbrown::HashSet;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     expr::{All, Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
@@ -56,6 +57,8 @@ impl<D> ExprLinter for MassPlurals<D>
 where
     D: Dictionary,
 {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/missing_preposition.rs
+++ b/harper-core/src/linting/missing_preposition.rs
@@ -9,6 +9,7 @@ use crate::patterns::UPOSSet;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct MissingPreposition {
     expr: Box<dyn Expr>,
@@ -41,6 +42,8 @@ impl Default for MissingPreposition {
 }
 
 impl ExprLinter for MissingPreposition {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/missing_to.rs
+++ b/harper-core/src/linting/missing_to.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use harper_brill::UPOS;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -216,6 +217,8 @@ impl Default for MissingTo {
 }
 
 impl ExprLinter for MissingTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/misspell.rs
+++ b/harper-core/src/linting/misspell.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -29,6 +30,8 @@ impl Default for Misspell {
 }
 
 impl ExprLinter for Misspell {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/mixed_bag.rs
+++ b/harper-core/src/linting/mixed_bag.rs
@@ -1,4 +1,5 @@
 use crate::CharStringExt;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::expr_linter::find_the_only_token_matching;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::{
@@ -29,6 +30,8 @@ impl Default for MixedBag {
 }
 
 impl ExprLinter for MixedBag {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/modal_of.rs
+++ b/harper-core/src/linting/modal_of.rs
@@ -5,6 +5,7 @@ use crate::patterns::ModalVerb;
 use crate::{Lrc, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ModalOf {
     expr: Box<dyn Expr>,
@@ -59,6 +60,8 @@ impl Default for ModalOf {
 }
 
 impl ExprLinter for ModalOf {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/modal_seem.rs
+++ b/harper-core/src/linting/modal_seem.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -68,6 +69,8 @@ impl Default for ModalSeem {
 }
 
 impl ExprLinter for ModalSeem {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/months.rs
+++ b/harper-core/src/linting/months.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token, TokenKind,
     expr::{Expr, FirstMatchOf, SequenceExpr},
@@ -87,6 +88,8 @@ impl Default for Months {
 }
 
 impl ExprLinter for Months {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/more_better.rs
+++ b/harper-core/src/linting/more_better.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::token::Token;
 use crate::token_string_ext::TokenStringExt;
@@ -29,6 +30,8 @@ impl Default for MoreBetter {
 }
 
 impl ExprLinter for MoreBetter {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/most_number.rs
+++ b/harper-core/src/linting/most_number.rs
@@ -4,6 +4,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct MostNumber {
     expr: Box<dyn Expr>,
@@ -35,6 +36,8 @@ impl Default for MostNumber {
 }
 
 impl ExprLinter for MostNumber {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/most_of_the_times.rs
+++ b/harper-core/src/linting/most_of_the_times.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, FixedPhrase, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::patterns::Word;
 use crate::{Lint, Token};
@@ -23,6 +24,8 @@ impl Default for MostOfTheTimes {
 }
 
 impl ExprLinter for MostOfTheTimes {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/multiple_sequential_pronouns.rs
+++ b/harper-core/src/linting/multiple_sequential_pronouns.rs
@@ -3,6 +3,7 @@ use super::expr_linter::ExprLinter;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::LintKind;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 use crate::{CharStringExt, Lint, Lrc, Token, TokenStringExt};
 
@@ -76,6 +77,8 @@ impl MultipleSequentialPronouns {
 }
 
 impl ExprLinter for MultipleSequentialPronouns {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/nail_on_the_head.rs
+++ b/harper-core/src/linting/nail_on_the_head.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -28,6 +29,8 @@ impl Default for NailOnTheHead {
 }
 
 impl ExprLinter for NailOnTheHead {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/need_to_noun.rs
+++ b/harper-core/src/linting/need_to_noun.rs
@@ -9,6 +9,7 @@ use crate::patterns::DerivedFrom;
 use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct NeedToNoun {
     expr: Box<dyn Expr>,
@@ -50,6 +51,8 @@ impl Default for NeedToNoun {
 }
 
 impl ExprLinter for NeedToNoun {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/no_match_for.rs
+++ b/harper-core/src/linting/no_match_for.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     expr::{Expr, FirstMatchOf, SequenceExpr},
@@ -35,6 +36,8 @@ impl Default for NoMatchFor {
 }
 
 impl ExprLinter for NoMatchFor {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/nobody.rs
+++ b/harper-core/src/linting/nobody.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct Nobody {
     expr: Box<dyn Expr>,
@@ -22,6 +23,8 @@ impl Default for Nobody {
 }
 
 impl ExprLinter for Nobody {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/nominal_wants.rs
+++ b/harper-core/src/linting/nominal_wants.rs
@@ -3,6 +3,7 @@ use harper_brill::UPOS;
 use crate::CharStringExt;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     dict_word_metadata::Person,
@@ -57,6 +58,8 @@ impl Default for NominalWants {
 }
 
 impl ExprLinter for NominalWants {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/noun_countability.rs
+++ b/harper-core/src/linting/noun_countability.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Span, Token, TokenStringExt,
     expr::{Expr, FirstMatchOf, LongestMatchOf, SequenceExpr},
@@ -66,6 +67,8 @@ impl Default for NounCountability {
 }
 
 impl ExprLinter for NounCountability {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/affect_to_effect.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use harper_brill::UPOS;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenKind,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -77,6 +78,8 @@ impl Default for AffectToEffect {
 }
 
 impl ExprLinter for AffectToEffect {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
+++ b/harper-core/src/linting/noun_verb_confusion/effect_affect/effect_to_affect.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use harper_brill::UPOS;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenKind,
     expr::{Expr, ExprMap, SequenceExpr},
@@ -40,6 +41,8 @@ impl Default for EffectToAffect {
 }
 
 impl ExprLinter for EffectToAffect {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
+++ b/harper-core/src/linting/noun_verb_confusion/noun_instead_of_verb/general.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, FirstMatchOf, LongestMatchOf, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::patterns::Word;
 use crate::{CharStringExt, Lrc, Token, patterns::WordSet};
@@ -85,6 +86,8 @@ impl Default for GeneralNounInsteadOfVerb {
 }
 
 impl ExprLinter for GeneralNounInsteadOfVerb {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
+++ b/harper-core/src/linting/noun_verb_confusion/verb_instead_of_noun.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token,
     expr::{Expr, SequenceExpr},
@@ -32,6 +33,8 @@ impl Default for VerbInsteadOfNoun {
 }
 
 impl ExprLinter for VerbInsteadOfNoun {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/of_course.rs
+++ b/harper-core/src/linting/of_course.rs
@@ -5,6 +5,7 @@
 
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -30,6 +31,8 @@ impl Default for OfCourse {
 }
 
 impl ExprLinter for OfCourse {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/on_floor.rs
+++ b/harper-core/src/linting/on_floor.rs
@@ -2,6 +2,7 @@ use crate::CharStringExt;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 use crate::{
     Lrc, Token, TokenStringExt,
@@ -57,6 +58,8 @@ impl Default for OnFloor {
 }
 
 impl ExprLinter for OnFloor {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/once_or_twice.rs
+++ b/harper-core/src/linting/once_or_twice.rs
@@ -3,6 +3,7 @@ use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct OnceOrTwice {
     expr: Box<dyn Expr>,
@@ -23,6 +24,8 @@ impl Default for OnceOrTwice {
 }
 
 impl ExprLinter for OnceOrTwice {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/one_and_the_same.rs
+++ b/harper-core/src/linting/one_and_the_same.rs
@@ -5,6 +5,7 @@ use crate::expr::SequenceExpr;
 use crate::{Lrc, Token, TokenStringExt, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct OneAndTheSame {
     expr: Box<dyn Expr>,
@@ -38,6 +39,8 @@ fn ws_word(word: &'static str) -> SequenceExpr {
 }
 
 impl ExprLinter for OneAndTheSame {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/open_compounds.rs
+++ b/harper-core/src/linting/open_compounds.rs
@@ -2,6 +2,7 @@ use crate::expr::{Expr, LongestMatchOf, SequenceExpr};
 use crate::{Lrc, Token, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 use hashbrown::HashMap;
 
 pub struct OpenCompounds {
@@ -66,6 +67,8 @@ impl Default for OpenCompounds {
 }
 
 impl ExprLinter for OpenCompounds {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/open_the_light.rs
+++ b/harper-core/src/linting/open_the_light.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
 
 pub struct OpenTheLight {
     expr: Box<dyn Expr>,
@@ -58,6 +59,8 @@ impl Default for OpenTheLight {
 }
 
 impl ExprLinter for OpenTheLight {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/orthographic_consistency.rs
+++ b/harper-core/src/linting/orthographic_consistency.rs
@@ -6,6 +6,8 @@ use crate::spell::{Dictionary, FstDictionary};
 use crate::{OrthFlags, Token};
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
+
 pub struct OrthographicConsistency {
     dict: Arc<FstDictionary>,
     expr: Box<dyn Expr>,
@@ -27,6 +29,8 @@ impl Default for OrthographicConsistency {
 }
 
 impl ExprLinter for OrthographicConsistency {
+    type Unit = Chunk;
+
     fn description(&self) -> &str {
         "Ensures word casing matches the dictionary's canonical orthography."
     }

--- a/harper-core/src/linting/ought_to_be.rs
+++ b/harper-core/src/linting/ought_to_be.rs
@@ -1,5 +1,6 @@
 use crate::TokenKind;
 use crate::expr::{AnchorStart, Expr, ExprMap, FixedPhrase, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -60,6 +61,8 @@ impl Default for OughtToBe {
 }
 
 impl ExprLinter for OughtToBe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/out_of_date.rs
+++ b/harper-core/src/linting/out_of_date.rs
@@ -4,6 +4,7 @@ use crate::expr::FixedPhrase;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct OutOfDate {
     expr: Box<dyn Expr>,
@@ -24,6 +25,8 @@ impl Default for OutOfDate {
 }
 
 impl ExprLinter for OutOfDate {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/oxymorons.rs
+++ b/harper-core/src/linting/oxymorons.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::FixedPhrase;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind};
 use crate::{Token, TokenStringExt};
 
@@ -50,6 +51,8 @@ impl Default for Oxymorons {
 }
 
 impl ExprLinter for Oxymorons {
+    type Unit = Chunk;
+
     /// Returns the underlying pattern.
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()

--- a/harper-core/src/linting/pique_interest.rs
+++ b/harper-core/src/linting/pique_interest.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{CharString, CharStringExt, Token, char_string::char_string, patterns::WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct PiqueInterest {
     expr: Box<dyn Expr>,
@@ -42,6 +43,8 @@ impl PiqueInterest {
 }
 
 impl ExprLinter for PiqueInterest {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/possessive_noun.rs
+++ b/harper-core/src/linting/possessive_noun.rs
@@ -2,6 +2,7 @@ use harper_brill::UPOS;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::expr::{All, Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::{UPOSSet, WordSet};
 use crate::spell::Dictionary;
 use crate::{Token, TokenKind};
@@ -53,6 +54,8 @@ impl<D> ExprLinter for PossessiveNoun<D>
 where
     D: Dictionary,
 {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/possessive_your.rs
+++ b/harper-core/src/linting/possessive_your.rs
@@ -4,6 +4,7 @@ use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct PossessiveYour {
     expr: Box<dyn Expr>,
@@ -26,6 +27,8 @@ impl Default for PossessiveYour {
 }
 
 impl ExprLinter for PossessiveYour {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/progressive_needs_be.rs
+++ b/harper-core/src/linting/progressive_needs_be.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenKind};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ProgressiveNeedsBe {
     expr: Box<dyn Expr>,
@@ -31,6 +32,8 @@ impl Default for ProgressiveNeedsBe {
 }
 
 impl ExprLinter for ProgressiveNeedsBe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/pronoun_are.rs
+++ b/harper-core/src/linting/pronoun_are.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -29,6 +30,8 @@ impl Default for PronounAre {
 }
 
 impl ExprLinter for PronounAre {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
+++ b/harper-core/src/linting/pronoun_contraction/avoid_contraction.rs
@@ -2,6 +2,7 @@ use crate::expr::{Expr, SequenceExpr};
 use crate::{Token, TokenKind};
 
 use super::super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct AvoidContraction {
     expr: Box<dyn Expr>,
@@ -20,6 +21,8 @@ impl Default for AvoidContraction {
 }
 
 impl ExprLinter for AvoidContraction {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/pronoun_contraction/should_contract.rs
+++ b/harper-core/src/linting/pronoun_contraction/should_contract.rs
@@ -8,6 +8,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, patterns::WordSet};
 
 use crate::Lint;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 
 /// See also:
@@ -61,6 +62,8 @@ impl ShouldContract {
 }
 
 impl ExprLinter for ShouldContract {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/pronoun_inflection_be.rs
+++ b/harper-core/src/linting/pronoun_inflection_be.rs
@@ -6,6 +6,7 @@ use crate::{Lrc, Token, TokenKind};
 
 use super::Suggestion;
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct PronounInflectionBe {
     expr: Box<dyn Expr>,
@@ -143,6 +144,8 @@ impl Default for PronounInflectionBe {
 }
 
 impl ExprLinter for PronounInflectionBe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/pronoun_knew.rs
+++ b/harper-core/src/linting/pronoun_knew.rs
@@ -3,6 +3,7 @@ use harper_brill::UPOS;
 use crate::expr::Expr;
 use crate::expr::LongestMatchOf;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -60,6 +61,8 @@ impl Default for PronounKnew {
 }
 
 impl ExprLinter for PronounKnew {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/proper_noun_capitalization_linters.rs
+++ b/harper-core/src/linting/proper_noun_capitalization_linters.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::{ExprLinter, LintGroup};
 use super::{Lint, LintKind, Suggestion};
 use crate::Document;
+use crate::linting::expr_linter::Chunk;
 use crate::parsers::PlainEnglish;
 use crate::spell::Dictionary;
 use crate::{Token, TokenStringExt};
@@ -66,6 +67,8 @@ impl<D: Dictionary + 'static> ProperNounCapitalizationLinter<D> {
 }
 
 impl<D: Dictionary + 'static> ExprLinter for ProperNounCapitalizationLinter<D> {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         &self.pattern_map
     }

--- a/harper-core/src/linting/quantifier_needs_of.rs
+++ b/harper-core/src/linting/quantifier_needs_of.rs
@@ -3,6 +3,7 @@ use crate::expr::{Expr, SequenceExpr};
 use crate::patterns::WordSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 /// Flags phrases like `a couple months` → should be `a couple **of** months`.
 pub struct QuantifierNeedsOf {
@@ -25,6 +26,8 @@ impl Default for QuantifierNeedsOf {
 }
 
 impl ExprLinter for QuantifierNeedsOf {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/quantifier_numeral_conflict.rs
+++ b/harper-core/src/linting/quantifier_numeral_conflict.rs
@@ -1,4 +1,5 @@
 use crate::expr::{All, Expr, SequenceExpr, SpelledNumberExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::patterns::{NominalPhrase, WordSet};
 use crate::token_string_ext::TokenStringExt;
@@ -37,6 +38,8 @@ impl Default for QuantifierNumeralConflict {
 }
 
 impl ExprLinter for QuantifierNumeralConflict {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/quite_quiet.rs
+++ b/harper-core/src/linting/quite_quiet.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, FirstMatchOf, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::{CharStringExt, Token, TokenKind, TokenStringExt};
 
@@ -52,6 +53,8 @@ impl Default for QuiteQuiet {
 }
 
 impl ExprLinter for QuiteQuiet {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/redundant_additive_adverbs.rs
+++ b/harper-core/src/linting/redundant_additive_adverbs.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token, TokenStringExt,
     expr::{Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
@@ -35,6 +36,8 @@ impl Default for RedundantAdditiveAdverbs {
 }
 
 impl ExprLinter for RedundantAdditiveAdverbs {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/regionalisms.rs
+++ b/harper-core/src/linting/regionalisms.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::ExprLinter;
+use crate::linting::expr_linter::Chunk;
 
 #[derive(PartialEq)]
 enum CanFlag {
@@ -485,6 +486,8 @@ impl Regionalisms {
 }
 
 impl ExprLinter for Regionalisms {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/roller_skated.rs
+++ b/harper-core/src/linting/roller_skated.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind, TokenStringExt,
     expr::{AnchorStart, Expr, ExprMap, SequenceExpr},
@@ -68,6 +69,8 @@ impl Default for RollerSkated {
 }
 
 impl ExprLinter for RollerSkated {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/safe_to_save.rs
+++ b/harper-core/src/linting/safe_to_save.rs
@@ -3,6 +3,7 @@ use harper_brill::UPOS;
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::{ModalVerb, UPOSSet, WordSet};
 use crate::{
     Token,
@@ -40,6 +41,8 @@ impl Default for SafeToSave {
 }
 
 impl ExprLinter for SafeToSave {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/save_to_safe.rs
+++ b/harper-core/src/linting/save_to_safe.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::OwnedExprExt;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -28,6 +29,8 @@ impl Default for SaveToSafe {
 }
 
 impl ExprLinter for SaveToSafe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/semicolon_apostrophe.rs
+++ b/harper-core/src/linting/semicolon_apostrophe.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -25,6 +26,8 @@ impl Default for SemicolonApostrophe {
 }
 
 impl ExprLinter for SemicolonApostrophe {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/shoot_oneself_in_the_foot.rs
+++ b/harper-core/src/linting/shoot_oneself_in_the_foot.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ShootOneselfInTheFoot {
     pattern: Box<dyn Expr>,
@@ -34,6 +35,8 @@ impl Default for ShootOneselfInTheFoot {
 }
 
 impl ExprLinter for ShootOneselfInTheFoot {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.pattern.as_ref()
     }

--- a/harper-core/src/linting/simple_past_to_past_participle.rs
+++ b/harper-core/src/linting/simple_past_to_past_participle.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     char_string::CharStringExt,
@@ -112,6 +113,8 @@ impl Default for SimplePastToPastParticiple {
 }
 
 impl ExprLinter for SimplePastToPastParticiple {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/since_duration.rs
+++ b/harper-core/src/linting/since_duration.rs
@@ -2,6 +2,7 @@ use crate::expr::{DurationExpr, Expr, LongestMatchOf, SequenceExpr};
 use crate::{Lrc, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 const AGO_VARIANTS: [&[char]; 3] = [&['a', 'g', 'o'], &['A', 'g', 'o'], &['A', 'G', 'O']];
 const FOR_VARIANTS: [&[char]; 3] = [&['f', 'o', 'r'], &['F', 'o', 'r'], &['F', 'O', 'R']];
@@ -46,6 +47,8 @@ impl Default for SinceDuration {
 }
 
 impl ExprLinter for SinceDuration {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/some_without_article.rs
+++ b/harper-core/src/linting/some_without_article.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -22,6 +23,8 @@ impl Default for SomeWithoutArticle {
 }
 
 impl ExprLinter for SomeWithoutArticle {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/something_is.rs
+++ b/harper-core/src/linting/something_is.rs
@@ -3,6 +3,7 @@ use crate::patterns::WordSet;
 use crate::{Token, TokenKind};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct SomethingIs {
     expr: Box<dyn Expr>,
@@ -25,6 +26,8 @@ impl Default for SomethingIs {
 }
 
 impl ExprLinter for SomethingIs {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/somewhat_something.rs
+++ b/harper-core/src/linting/somewhat_something.rs
@@ -2,6 +2,7 @@ use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct SomewhatSomething {
     expr: Box<dyn Expr>,
@@ -22,6 +23,8 @@ impl Default for SomewhatSomething {
 }
 
 impl ExprLinter for SomewhatSomething {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/sought_after.rs
+++ b/harper-core/src/linting/sought_after.rs
@@ -2,6 +2,7 @@ use crate::expr::{Expr, SequenceExpr, SpaceOrHyphen};
 use crate::{Token, TokenKind};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct SoughtAfter {
     expr: Box<dyn Expr>,
@@ -35,6 +36,8 @@ impl Default for SoughtAfter {
 }
 
 impl ExprLinter for SoughtAfter {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/split_words.rs
+++ b/harper-core/src/linting/split_words.rs
@@ -7,6 +7,7 @@ use crate::linting::{LintKind, Suggestion};
 use crate::spell::{FstDictionary, TrieDictionary};
 
 use super::{ExprLinter, Lint};
+use crate::linting::expr_linter::Chunk;
 
 pub struct SplitWords {
     dict: Arc<TrieDictionary<Arc<FstDictionary>>>,
@@ -29,6 +30,8 @@ impl Default for SplitWords {
 }
 
 impl ExprLinter for SplitWords {
+    type Unit = Chunk;
+
     fn description(&self) -> &str {
         "Finds missing spaces in improper compound words."
     }

--- a/harper-core/src/linting/take_serious.rs
+++ b/harper-core/src/linting/take_serious.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -35,6 +36,8 @@ impl Default for TakeSerious {
 }
 
 impl ExprLinter for TakeSerious {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/that_than.rs
+++ b/harper-core/src/linting/that_than.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenKind,
     expr::{Expr, SequenceExpr},
@@ -27,6 +28,8 @@ impl Default for ThatThan {
 }
 
 impl ExprLinter for ThatThan {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/that_which.rs
+++ b/harper-core/src/linting/that_which.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use crate::{Lrc, Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ThatWhich {
     expr: Box<dyn Expr>,
@@ -32,6 +33,8 @@ impl Default for ThatWhich {
 }
 
 impl ExprLinter for ThatWhich {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/the_how_why.rs
+++ b/harper-core/src/linting/the_how_why.rs
@@ -1,6 +1,7 @@
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -60,6 +61,8 @@ impl Default for TheHowWhy {
 }
 
 impl ExprLinter for TheHowWhy {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         &self.expr
     }

--- a/harper-core/src/linting/the_my.rs
+++ b/harper-core/src/linting/the_my.rs
@@ -2,6 +2,7 @@ use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token, TokenStringExt,
     patterns::{Word, WordSet},
@@ -36,6 +37,8 @@ impl Default for TheMy {
 }
 
 impl ExprLinter for TheMy {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/then_than.rs
+++ b/harper-core/src/linting/then_than.rs
@@ -1,6 +1,7 @@
 use super::{ExprLinter, Lint, LintKind};
 use crate::expr::{All, Expr, FirstMatchOf, FixedPhrase, SequenceExpr};
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::{Invert, Word, WordSet};
 use crate::{CharStringExt, Token, TokenKind};
 
@@ -69,6 +70,8 @@ impl Default for ThenThan {
 }
 
 impl ExprLinter for ThenThan {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/theres.rs
+++ b/harper-core/src/linting/theres.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     CharStringExt, Token,
     expr::SequenceExpr,
@@ -26,6 +27,8 @@ impl Default for Theres {
 }
 
 impl ExprLinter for Theres {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn crate::expr::Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/theses_these.rs
+++ b/harper-core/src/linting/theses_these.rs
@@ -1,6 +1,7 @@
 use super::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::Token;
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::UPOSSet;
 use harper_brill::UPOS;
 
@@ -22,6 +23,8 @@ impl Default for ThesesThese {
 }
 
 impl ExprLinter for ThesesThese {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/thing_think.rs
+++ b/harper-core/src/linting/thing_think.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, FirstMatchOf, FixedPhrase, SequenceExpr},
@@ -77,6 +78,8 @@ impl Default for ThingThink {
 }
 
 impl ExprLinter for ThingThink {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/though_thought.rs
+++ b/harper-core/src/linting/though_thought.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::expr_linter::find_the_only_token_matching;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::{CharStringExt, Token, TokenKind};
@@ -29,6 +30,8 @@ impl Default for ThoughThought {
 }
 
 impl ExprLinter for ThoughThought {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/throw_away.rs
+++ b/harper-core/src/linting/throw_away.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, SequenceExpr},
@@ -22,6 +23,8 @@ impl Default for ThrowAway {
 }
 
 impl ExprLinter for ThrowAway {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_adverb.rs
+++ b/harper-core/src/linting/to_adverb.rs
@@ -5,6 +5,7 @@ use crate::patterns::{UPOSSet, WordSet};
 use crate::{Span, Token};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 const AMBIGUOUS_ADVERBS: &[&str] = &["just", "not"];
 
@@ -30,6 +31,8 @@ impl Default for ToAdverb {
 }
 
 impl ExprLinter for ToAdverb {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_end.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooAdjectiveEnd {
     expr: Box<dyn Expr>,
@@ -38,6 +39,8 @@ impl Default for ToTooAdjectiveEnd {
 }
 
 impl ExprLinter for ToTooAdjectiveEnd {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjective_punct.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooAdjectivePunct {
     expr: Box<dyn Expr>,
@@ -36,6 +37,8 @@ impl Default for ToTooAdjectivePunct {
 }
 
 impl ExprLinter for ToTooAdjectivePunct {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_adjverb_ed_punct.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adjverb_ed_punct.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooAdjVerbEdPunct {
     expr: Box<dyn Expr>,
@@ -36,6 +37,8 @@ impl Default for ToTooAdjVerbEdPunct {
 }
 
 impl ExprLinter for ToTooAdjVerbEdPunct {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_adverb.rs
+++ b/harper-core/src/linting/to_two_too/to_too_adverb.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooAdverb {
     expr: Box<dyn Expr>,
@@ -34,6 +35,8 @@ impl Default for ToTooAdverb {
 }
 
 impl ExprLinter for ToTooAdverb {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_chunk_start_comma.rs
+++ b/harper-core/src/linting/to_two_too/to_too_chunk_start_comma.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooChunkStartComma {
     expr: Box<dyn Expr>,
@@ -26,6 +27,8 @@ impl Default for ToTooChunkStartComma {
 }
 
 impl ExprLinter for ToTooChunkStartComma {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_degree_words.rs
+++ b/harper-core/src/linting/to_two_too/to_too_degree_words.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooDegreeWords {
     expr: Box<dyn Expr>,
@@ -34,6 +35,8 @@ impl Default for ToTooDegreeWords {
 }
 
 impl ExprLinter for ToTooDegreeWords {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
+++ b/harper-core/src/linting/to_two_too/to_too_pronoun_end.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct ToTooPronounEnd {
     expr: Box<dyn Expr>,
@@ -47,6 +48,8 @@ impl Default for ToTooPronounEnd {
 }
 
 impl ExprLinter for ToTooPronounEnd {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/to_two_too/too_to.rs
+++ b/harper-core/src/linting/to_two_too/too_to.rs
@@ -6,6 +6,7 @@ use crate::expr::SequenceExpr;
 use crate::patterns::UPOSSet;
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct TooTo {
     expr: Box<dyn Expr>,
@@ -27,6 +28,8 @@ impl Default for TooTo {
 }
 
 impl ExprLinter for TooTo {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/touristic.rs
+++ b/harper-core/src/linting/touristic.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, LongestMatchOf, SequenceExpr},
@@ -89,6 +90,8 @@ impl Default for Touristic {
 }
 
 impl ExprLinter for Touristic {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/update_place_names.rs
+++ b/harper-core/src/linting/update_place_names.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, FixedPhrase, LongestMatchOf};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::{Lint, Token, TokenStringExt};
 
@@ -97,6 +98,8 @@ impl<'a> UpdatePlaceNames<'a> {
 }
 
 impl<'a> ExprLinter for UpdatePlaceNames<'a> {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/use_genitive.rs
+++ b/harper-core/src/linting/use_genitive.rs
@@ -2,6 +2,7 @@ use crate::expr::Expr;
 use crate::expr::FirstMatchOf;
 use crate::expr::SequenceExpr;
 use crate::expr::WordExprGroup;
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, LintKind, Suggestion};
 use crate::patterns::Word;
 use crate::{Lint, Lrc, Token};
@@ -56,6 +57,8 @@ impl UseGenitive {
 }
 
 impl ExprLinter for UseGenitive {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/verb_to_adjective.rs
+++ b/harper-core/src/linting/verb_to_adjective.rs
@@ -8,6 +8,7 @@ use crate::patterns::WordSet;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind};
+use crate::linting::expr_linter::Chunk;
 
 pub struct VerbToAdjective {
     expr: Box<dyn Expr>,
@@ -40,6 +41,8 @@ impl Default for VerbToAdjective {
 }
 
 impl ExprLinter for VerbToAdjective {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/very_unique.rs
+++ b/harper-core/src/linting/very_unique.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token, TokenStringExt,
     expr::{Expr, SequenceExpr},
@@ -25,6 +26,8 @@ impl Default for VeryUnique {
 }
 
 impl ExprLinter for VeryUnique {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/vice_versa.rs
+++ b/harper-core/src/linting/vice_versa.rs
@@ -1,4 +1,5 @@
 use crate::expr::{Expr, SequenceExpr};
+use crate::linting::expr_linter::Chunk;
 use crate::linting::{ExprLinter, Lint, LintKind, Suggestion};
 use crate::{Token, TokenStringExt};
 
@@ -86,6 +87,8 @@ impl Default for ViceVersa {
 }
 
 impl ExprLinter for ViceVersa {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/was_aloud.rs
+++ b/harper-core/src/linting/was_aloud.rs
@@ -4,6 +4,7 @@ use crate::TokenStringExt;
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
 use crate::linting::Suggestion;
+use crate::linting::expr_linter::Chunk;
 use crate::patterns::WordSet;
 
 pub struct WasAloud {
@@ -24,6 +25,8 @@ impl Default for WasAloud {
 }
 
 impl ExprLinter for WasAloud {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/way_too_adjective.rs
+++ b/harper-core/src/linting/way_too_adjective.rs
@@ -5,6 +5,7 @@ use crate::expr::{All, Expr, OwnedExprExt, SequenceExpr};
 use crate::patterns::{UPOSSet, WordSet};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct WayTooAdjective {
     expr: Box<dyn Expr>,
@@ -38,6 +39,8 @@ impl Default for WayTooAdjective {
 }
 
 impl ExprLinter for WayTooAdjective {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/well_educated.rs
+++ b/harper-core/src/linting/well_educated.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct WellEducated {
     expr: Box<dyn Expr>,
@@ -31,6 +32,8 @@ impl Default for WellEducated {
 }
 
 impl ExprLinter for WellEducated {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/whereas.rs
+++ b/harper-core/src/linting/whereas.rs
@@ -3,6 +3,7 @@ use crate::expr::SequenceExpr;
 use crate::{Token, TokenStringExt};
 
 use super::{ExprLinter, Lint, LintKind, Suggestion};
+use crate::linting::expr_linter::Chunk;
 
 pub struct Whereas {
     expr: Box<dyn Expr>,
@@ -22,6 +23,8 @@ impl Default for Whereas {
 }
 
 impl ExprLinter for Whereas {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/widely_accepted.rs
+++ b/harper-core/src/linting/widely_accepted.rs
@@ -1,5 +1,6 @@
 use crate::expr::Expr;
 use crate::expr::SequenceExpr;
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -22,6 +23,8 @@ impl Default for WidelyAccepted {
 }
 
 impl ExprLinter for WidelyAccepted {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         &self.expr
     }

--- a/harper-core/src/linting/win_prize.rs
+++ b/harper-core/src/linting/win_prize.rs
@@ -1,5 +1,6 @@
 use crate::expr::SequenceExpr;
 use crate::expr::{Expr, OwnedExprExt};
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Lrc, Token,
     linting::{ExprLinter, Lint, LintKind, Suggestion},
@@ -35,6 +36,8 @@ impl Default for WinPrize {
 }
 
 impl ExprLinter for WinPrize {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }

--- a/harper-core/src/linting/would_never_have.rs
+++ b/harper-core/src/linting/would_never_have.rs
@@ -1,3 +1,4 @@
+use crate::linting::expr_linter::Chunk;
 use crate::{
     Token,
     expr::{Expr, FixedPhrase, SequenceExpr},
@@ -37,6 +38,8 @@ impl Default for WouldNeverHave {
 }
 
 impl ExprLinter for WouldNeverHave {
+    type Unit = Chunk;
+
     fn expr(&self) -> &dyn Expr {
         self.expr.as_ref()
     }


### PR DESCRIPTION
# Issues 
N/A

# Description

Implementation of `ExprLinter` for sentences _or_ chunks using Rust associated types.

# How Has This Been Tested?

One sentence-iterator unit test.

# Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] I have performed a self-review of my own code
- [x] I have added tests to cover my changes
